### PR TITLE
Fixed the `release.yml` workflow file to install snapcraft before building to avoid Ubuntu Error!

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
+  install-snapcraft:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Snapcraft
+      uses: samuelmeuli/action-snapcraft@v1
+
   release:
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Dear Patrick,
  I have edited the `release.yml` workflow file located at `.github/workflows/release.yml` to install **Snapcraft** before building to avoid the produced errors I saw in your actions's logs.